### PR TITLE
Set up automated tests for the web

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,10 @@ jobs:
       run: bun install
       
     - name: Install Playwright browsers
-      run: bun run test:install
+      run: bun run test:install --with-deps
+      
+    - name: Import test data
+      run: bun import
       
     - name: Run Playwright tests
       run: bun run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: latest
+        
+    - name: Install dependencies
+      run: bun install
+      
+    - name: Install Playwright browsers
+      run: bun run test:install
+      
+    - name: Run Playwright tests
+      run: bun run test
+      
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@
 ## Important Notes
 
 - The `docs/` directory contains generated HTML files. Don't read or modify these directly; instead, update the generation scripts.
+- When running in GitHub Actions (detected by presence of `<pr_or_issue_body>` tags in the initial prompt), Claude cannot directly create workflow files and must provide file contents in comments for manual creation.
 
 ## Environment
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "module": "src/index.ts",
   "type": "module",
   "devDependencies": {
+    "@playwright/test": "^1.49.1",
     "@tsconfig/bun": "^1.0.7",
     "@types/bun": "latest",
     "@types/lodash-es": "^4.17.12",
@@ -40,6 +41,8 @@
     "export": "bun run scripts/export.ts -o snapshot.jsonl.br",
     "import": "bun run scripts/import.ts -i snapshot.jsonl.br",
     "html": "bun run scripts/webBuilder.ts",
-    "dev": "env PORT=2518 bun --watch scripts/webServer.ts"
+    "dev": "env PORT=2518 bun --watch scripts/webServer.ts",
+    "test": "playwright test",
+    "test:install": "playwright install"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:2518',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+
+  webServer: {
+    command: 'bun dev',
+    url: 'http://localhost:2518',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/web.spec.ts
+++ b/tests/web.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+test('onet_m6.html page contains required headings', async ({ page }) => {
+  await page.goto('/onet_m6.html');
+
+  // Check that "Overall ranking" heading exists
+  await expect(page.getByRole('heading', { name: 'Overall ranking' })).toBeVisible();
+
+  // Check that "Per question" heading exists
+  await expect(page.getByRole('heading', { name: 'Per question' })).toBeVisible();
+});

--- a/tests/web.spec.ts
+++ b/tests/web.spec.ts
@@ -4,15 +4,9 @@ test('onet_m6.html page contains required headings', async ({ page }) => {
   // Navigate to the page
   await page.goto('/onet_m6.html');
 
-  // Wait for the page to load completely
-  await page.waitForLoadState('networkidle');
-
-  // Check that page loads successfully (not 404/500)
-  await expect(page.locator('h1')).toBeVisible();
-
   // Check that "Overall ranking" heading exists
-  await expect(page.locator('h2:has-text("Overall ranking")')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Overall ranking' })).toBeVisible();
 
   // Check that "Per question" heading exists  
-  await expect(page.locator('h2:has-text("Per question")')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Per question' })).toBeVisible();
 });

--- a/tests/web.spec.ts
+++ b/tests/web.spec.ts
@@ -1,11 +1,18 @@
 import { test, expect } from '@playwright/test';
 
 test('onet_m6.html page contains required headings', async ({ page }) => {
+  // Navigate to the page
   await page.goto('/onet_m6.html');
 
-  // Check that "Overall ranking" heading exists
-  await expect(page.getByRole('heading', { name: 'Overall ranking' })).toBeVisible();
+  // Wait for the page to load completely
+  await page.waitForLoadState('networkidle');
 
-  // Check that "Per question" heading exists
-  await expect(page.getByRole('heading', { name: 'Per question' })).toBeVisible();
+  // Check that page loads successfully (not 404/500)
+  await expect(page.locator('h1')).toBeVisible();
+
+  // Check that "Overall ranking" heading exists
+  await expect(page.locator('h2:has-text("Overall ranking")')).toBeVisible();
+
+  // Check that "Per question" heading exists  
+  await expect(page.locator('h2:has-text("Per question")')).toBeVisible();
 });


### PR DESCRIPTION
Set up Playwright Test for web automation

- Add @playwright/test dependency
- Create Playwright configuration with multiple browsers
- Add test script commands to package.json
- Write test for onet_m6.html page checking for "Overall ranking" and "Per question" headings
- Configure web server integration for testing

Closes #7

Generated with [Claude Code](https://claude.ai/code)